### PR TITLE
Add postinstall script to generate Prisma client

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@prisma/client": "^5.4.2",


### PR DESCRIPTION
This pull request adds a postinstall script to the package.json file that generates the Prisma client. This will ensure that the client is always up-to-date and ready to use.

No issues are fixed in this pull request.